### PR TITLE
Fix build script by removing deprecated flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "scripts": {
     "dev": "next dev",
-    "build": "cross-env NODE_OPTIONS=--openssl-legacy-provider next build",
+    "build": "next build",
     "start": "next start",
     "build-stats": "cross-env ANALYZE=true npm run build",
     "export": "next export",


### PR DESCRIPTION
## Summary
- remove `--openssl-legacy-provider` from the build script

## Testing
- `npm run build-prod`

------
https://chatgpt.com/codex/tasks/task_e_6859bdc4e11c83279d83c5266d93eb02